### PR TITLE
docs(readme): Add line for import renderer in client middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If you want to change the path of the client entry point, add a `src` attribute 
 ```tsx
 // src/client/main.tsx
 import { Script, Link } from 'hono-vite-react-stack/components'
+import { reactRenderer } from '@hono/react-renderer'
 
 export const renderer = reactRenderer(({ children }) => {
   return (


### PR DESCRIPTION
When following the README, missing package and import in client middleware was confusing. 
Fixes https://github.com/yusukebe/hono-vite-react-stack/issues/19